### PR TITLE
Adds required parameter when numprocs > 1

### DIFF
--- a/templates/supervisor.conf.erb
+++ b/templates/supervisor.conf.erb
@@ -7,6 +7,7 @@ autorestart=true
 redirect_stderr=True
 <%- if @numprocs -%>
 numprocs=<%= @numprocs %>
+process_name=%(process_num)02d
 <%- end -%>
 <%- if @startsecs -%>
 startsecs=<%= @startsecs %>


### PR DESCRIPTION
Sorry, I didnt add this before. I've tested this on various Ubuntu's now.